### PR TITLE
Fix find device by exact match

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "testcafe-browser-provider-ios",
-  "version": "0.0.5",
+  "version": "0.1.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -1820,14 +1820,6 @@
       "integrity": "sha1-+cmvVGSvoeepcUWKi97yqpTVuxk=",
       "dev": true
     },
-    "desired-capabilities": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/desired-capabilities/-/desired-capabilities-0.1.0.tgz",
-      "integrity": "sha1-84YNEu3g2sgZpHzJWaaMULqbqD4=",
-      "requires": {
-        "extend": "^3.0.0"
-      }
-    },
     "detect-file": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/detect-file/-/detect-file-1.0.0.tgz",
@@ -2244,7 +2236,8 @@
     "extend": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
-      "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g=="
+      "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
+      "dev": true
     },
     "extend-shallow": {
       "version": "3.0.2",

--- a/package.json
+++ b/package.json
@@ -25,8 +25,7 @@
   ],
   "license": "MIT",
   "dependencies": {
-    "babel-runtime": "^6.11.6",
-    "desired-capabilities": "^0.1.0"
+    "babel-runtime": "^6.11.6"
   },
   "devDependencies": {
     "babel-eslint": "^6.1.2",

--- a/src/device_list.js
+++ b/src/device_list.js
@@ -1,0 +1,39 @@
+export default {
+    find (list, { platform, name }) {
+        // Do a lowercase match on the device they have asked for so we can be nice about iphone vs iPhone
+        platform = platform.toLowerCase();
+        name = name.toLowerCase();
+
+        const device = list.find((d) => {
+            return (platform === 'any' || platform === `${d.os} ${d.version}`) &&
+                name === d.name.toLowerCase();
+        });
+
+        if (typeof device === 'undefined')
+            return null;
+        return device;
+    },
+
+    get (rawList) {
+        const parsedList = [];
+
+        for (const entry of rawList) {
+            try {
+                var { udid, os_version:osVersion, state, name } = JSON.parse(entry);
+            }
+            catch (e) {
+                continue;
+            }
+            const [ os, version ] = osVersion.split(' ');
+            const device = { name, os, version, udid, state };
+
+            // We can't run tests on tvOS or watchOS, so only include iOS devices
+            if (device.os && device.os.startsWith('iOS'))
+                parsedList.push(device);
+        }
+
+        return parsedList.sort((a, b) => {
+            return parseFloat(b.version) - parseFloat(a.version);
+        });
+    }
+};

--- a/src/device_list.js
+++ b/src/device_list.js
@@ -5,7 +5,7 @@ export default {
         name = name.toLowerCase();
 
         const device = list.find((d) => {
-            return (platform === 'any' || platform === `${d.os} ${d.version}`) &&
+            return (platform === 'any' || platform === `${d.os} ${d.version}`.toLowerCase()) &&
                 name === d.name.toLowerCase();
         });
 

--- a/src/device_list.js
+++ b/src/device_list.js
@@ -14,7 +14,7 @@ export default {
         return device;
     },
 
-    get (rawList) {
+    parse (rawList) {
         const parsedList = [];
 
         for (const entry of rawList) {

--- a/src/index.js
+++ b/src/index.js
@@ -1,6 +1,7 @@
 import parseCapabilities from 'desired-capabilities';
 import childProcess from 'child_process';
 import idbCompanion from './idb_companion.js';
+import deviceList from './device_list.js';
 
 export default {
     // Multiple browsers support
@@ -62,47 +63,11 @@ export default {
 
     _getAvailableDevices () {
         var rawDevices = idbCompanion.list();
-        var availableDevices = [];
 
-        for (var entry of rawDevices) {
-            var device;
-
-            try {
-                var { udid, os_version:osVersion, state, name } = JSON.parse(entry);
-            }
-            catch (e) {
-                // If JSON exception encountered, skip it.
-                continue;
-            }
-            var [ os, version ] = osVersion.split(' ');
-
-            device = { name, os, version, udid, state };
-
-            // We can't run tests on tvOS or watchOS, so only include iOS devices
-            if (device.os && device.os.startsWith('iOS'))
-                availableDevices.push(device);
-        }
-
-        availableDevices.sort((a, b) => {
-            return parseFloat(b.version) - parseFloat(a.version);
-        });
-
-        return availableDevices;
+        return deviceList.get(rawDevices);
     },
 
     _getDeviceFromDetails ({ platform, browserName }) {
-        // Do a lowercase match on the device they have asked for so we can be nice about iphone vs iPhone
-        platform = platform.toLowerCase();
-        browserName = browserName.toLowerCase();
-
-        var device = this.availableDevices.find((d) => {
-            return (platform === 'any' || platform === `${d.os} ${d.version}`) &&
-                browserName === d.name.toLowerCase();
-        });
-
-
-        if (typeof device === 'undefined')
-            return null;
-        return device;
+        return deviceList.find(this.availableDevices, { platform, name: browserName });
     }
 };

--- a/src/index.js
+++ b/src/index.js
@@ -43,7 +43,7 @@ export default {
     async init () {
         var rawDevices = idbCompanion.list();
 
-        this.availableDevices = deviceList.get(rawDevices);
+        this.availableDevices = deviceList.parse(rawDevices);
     },
 
     async getBrowserList () {

--- a/test/test_device_list.js
+++ b/test/test_device_list.js
@@ -1,0 +1,82 @@
+const assert = require('assert');
+const deviceList = require('../lib/device_list.js');
+const sortedList = [
+    {
+        name:    'iPhone X',
+        os:      'iOS',
+        version: '14.3'
+    },
+    {
+        name:    'iPad Pro (9.7-inch)',
+        os:      'iOS',
+        version: '14.3'
+    },
+    {
+        name:    'iPhone 12',
+        os:      'iOS',
+        version: '14.4'
+    },
+    {
+        name:    'iPhone X',
+        os:      'iOS',
+        version: '12.0'
+    },
+];
+const rawIdbList = `{"model":"iPhone 5s","os_version":"iOS 12.2","udid":"F610650B-2B6F-45D7-9662-FB104B6F711F","architecture":"x86_64","type":"simulator","name":"iPhone 5s","state":"Shutdown"}
+{"model":"iPhone 11","os_version":"iOS 13.0","udid":"300B61F9-83D6-47E3-BCBF-1E084596AB82","architecture":"x86_64","type":"simulator","name":"iPhone 11","state":"Shutdown"}
+{"model":"iPhone X","os_version":"iOS 13.2","udid":"599BCD4D-9064-4493-96B9-1C687CE244D6","architecture":"x86_64","type":"simulator","name":"iPhone X - 13.2","state":"Shutdown"}
+{"model":"Apple TV 4K","os_version":"tvOS 13.3","udid":"E6F65367-C3A4-45A8-A939-A7637488E1F3","architecture":"x86_64","type":"simulator","name":"iPhone 11","state":"Shutdown"}
+{"model":"iPhone 11","os_version":"iOS 13.3","udid":"E6F65367-C3A4-45A8-A939-A7637488E1F3","architecture":"x86_64","type":"simulator","name":"iPhone 11","state":"Shutdown"}
+{"model":"iPad Pro (9.7-inch)","os_version":"iOS 13.3","udid":"AE4B7B8A-CA48-48C9-8325-B957D95BEBD5","architecture":"x86_64","type":"simulator","name":"iPad Pro (9.7-inch)","state":"Shutdown"}`.split('\n');
+
+describe('device_list', function () {
+    describe('#find', function () {
+        before(function () {
+        });
+        it('should find the latest when any version is provided', function () {
+            const device = deviceList.find(sortedList, { platform: 'any', name: 'iPhone X' });
+
+            assert(device !== null);
+            assert(device.version === '14.3');
+        });
+        it('should find an exact match', function () {
+            const device = deviceList.find(sortedList, { platform: 'iOS 14.3', name: 'iPad Pro (9.7-inch)' });
+
+            assert(device !== null);
+            assert(device.name === 'iPad Pro (9.7-inch)');
+            assert(device.version === '14.3');
+        });
+        it('should return null if no match found', function () {
+            const device = deviceList.find(sortedList, { platform: 'tvOS 14.3', name: 'Apple TV 4K' });
+
+            assert(device === null);
+        });
+    });
+    describe('#get', function () {
+        it('should return a list of devices sorted by descending versions', function () {
+            const parsedList = deviceList.get(rawIdbList);
+            const isSorted = parsedList.every((device, index) => { // eslint-disable-line max-nested-callbacks
+                if (index === parsedList.length - 1)
+                    return true;
+                return parseFloat(device.version) >= parseFloat(parsedList[index + 1].version);
+            });
+
+            assert(parsedList !== null);
+            assert(parsedList.length > 0);
+            assert(isSorted);
+        });
+        it('should only include iOS devices', function () {
+            const parsedList = deviceList.get(rawIdbList);
+            const onlyIOS = parsedList.every((device) => { // eslint-disable-line max-nested-callbacks
+                return device.os === 'iOS';
+            });
+
+            assert(onlyIOS);
+        });
+        it('should always return a list', function () {
+            const parsedList = deviceList.get(['not json']);
+
+            assert(Array.isArray(parsedList));
+        });
+    });
+});

--- a/test/test_device_list.js
+++ b/test/test_device_list.js
@@ -52,9 +52,9 @@ describe('device_list', function () {
             assert(device === null);
         });
     });
-    describe('#get', function () {
+    describe('#parse', function () {
         it('should return a list of devices sorted by descending versions', function () {
-            const parsedList = deviceList.get(rawIdbList);
+            const parsedList = deviceList.parse(rawIdbList);
             const isSorted = parsedList.every((device, index) => { // eslint-disable-line max-nested-callbacks
                 if (index === parsedList.length - 1)
                     return true;
@@ -66,7 +66,7 @@ describe('device_list', function () {
             assert(isSorted);
         });
         it('should only include iOS devices', function () {
-            const parsedList = deviceList.get(rawIdbList);
+            const parsedList = deviceList.parse(rawIdbList);
             const onlyIOS = parsedList.every((device) => { // eslint-disable-line max-nested-callbacks
                 return device.os === 'iOS';
             });
@@ -74,7 +74,7 @@ describe('device_list', function () {
             assert(onlyIOS);
         });
         it('should always return a list', function () {
-            const parsedList = deviceList.get(['not json']);
+            const parsedList = deviceList.parse(['not json']);
 
             assert(Array.isArray(parsedList));
         });

--- a/test/test_idb_companion.js
+++ b/test/test_idb_companion.js
@@ -5,11 +5,10 @@ var process = require('process');
 var childProcess = require('child_process');
 
 
-afterEach(() => {
-    sinon.restore();
-});
-
 describe('idb_companion', function () {
+    afterEach(() => {
+        sinon.restore();
+    });
     describe('#boot()', function () {
         it('should call _exec with correct args', function () {
             var execStub = sinon.stub(idbCompanion, '_exec').returns({ rc: 0, stdout: '' });


### PR DESCRIPTION
* Always use lowercase comparison between user defined strings and device properties.
* Move device related logic to a separate module
* Add tests for device module
* Remove unneeded `desired-capabilities` dependency