### PR TITLE
Make idb_companion calls async

### DIFF
--- a/src/idb_companion.js
+++ b/src/idb_companion.js
@@ -38,6 +38,8 @@ export default {
                 execOpts['timeout'] = opts.timeout;
             childProcess.exec(`idb_companion ${args.join(' ')}`, execOpts, (error, stdout, stderr) => {
                 if (error !== null) {
+                    // This is not an exact way of detecting a timeout.
+                    // afaict, there's no reliable way to know whether the process timed out.
                     if (error.killed === true && error.signal === 'SIGKILL') {
                         debug('_exec errored with timeout');
                         reject({ rc: 65, stdout, stderr });

--- a/src/index.js
+++ b/src/index.js
@@ -32,27 +32,27 @@ export default {
         // If the device is not Shutdown we don't know what state it's in - shut it down and reboot it
         if (device.state !== 'Shutdown') {
             debug('Forcing shutdown of device before test');
-            idbCompanion.shutdown(device.udid);
+            await idbCompanion.shutdown(device.udid);
         }
 
         debug(`Booting device (${device.name} ${device.os} ${device.version})`);
         // Timeout in seconds
         const timeout = process.env.IOS_BOOT_TIMEOUT || 60;
 
-        idbCompanion.boot(device.udid, timeout * 1000);
+        await idbCompanion.boot(device.udid, timeout * 1000);
 
         debug(`Opening url: ${pageUrl}`);
         childProcess.execSync(`xcrun simctl openurl ${device.udid} ${pageUrl}`, { stdio: 'ignore' });
     },
 
     async closeBrowser (id) {
-        idbCompanion.shutdown(this.currentBrowsers[id].udid);
+        await idbCompanion.shutdown(this.currentBrowsers[id].udid);
     },
 
     // Optional - implement methods you need, remove other methods
     async init () {
         debug('Initializing plugin');
-        var rawDevices = idbCompanion.list();
+        var rawDevices = await idbCompanion.list();
 
         this.availableDevices = deviceList.parse(rawDevices);
         debug(`Found ${this.availableDevices.length} devices`);


### PR DESCRIPTION
The plugin interface defines async functions, but we were using `execSync` for `idb_companion` shell calls. Booting a sim can take upwards of 60s, depending on the host system. So don't block testcafe from executing other async tasks while waiting for the simulator to boot.