### PR TITLE
Optionally skip simulator shutdown

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -45,6 +45,11 @@ export default {
     },
 
     async closeBrowser (id) {
+        const skipShutdown = process.env.IOS_SKIP_SHUTDOWN || '';
+
+        if (skipShutdown !== '')
+            return;
+
         await idbCompanion.shutdown(this.currentBrowsers[id].udid);
     },
 


### PR DESCRIPTION
Set env var `IOS_SKIP_SHUTDOWN` to any non empty string to skip the sim shutdown step at the end of a test. Useful if testing in a clean virtualized test environment.