### PR TITLE
Retry openurl on failure

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -1,6 +1,7 @@
 import js from "@eslint/js";
 import prettier from "eslint-config-prettier";
 import mocha from "eslint-plugin-mocha";
+import globals from "globals";
 
 export default [
   {
@@ -8,6 +9,9 @@ export default [
     languageOptions: {
       ecmaVersion: "latest",
       sourceType: "module",
+      globals: {
+        ...globals.node,
+      },
     },
     rules: {
       ...prettier.rules,

--- a/src/index.js
+++ b/src/index.js
@@ -9,7 +9,7 @@ const process = require("process");
  * A utility function to introduce a delay.
  * @param ms - The delay in milliseconds.
  */
-const delay = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
+const delay = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
 
 module.exports = {
   // Multiple browsers support

--- a/src/index.js
+++ b/src/index.js
@@ -9,8 +9,6 @@ const process = require("process");
  * A utility function to introduce a delay.
  * @param ms - The delay in milliseconds.
  */
-const util = require("util");
-
 const delay = util.promisify(setTimeout);
 
 module.exports = {

--- a/src/index.js
+++ b/src/index.js
@@ -60,7 +60,7 @@ module.exports = {
         await exec(`xcrun simctl openurl ${device.udid} ${pageUrl}`);
         return; // Success, exit function.
       } catch (error) {
-
+        debug(`Error opening URL: ${error}`);
         if (attempt >= maxRetries) {
           throw new Error(
             `Failed to open URL on simulator after ${maxRetries} attempts.`,
@@ -73,6 +73,7 @@ module.exports = {
           await idbCompanion.shutdown(device.udid);
           await idbCompanion.boot(device.udid, timeout * 1000);
         } catch (recoveryError) {
+          debug(`Recovery error: ${recoveryError}`);
           throw new Error('Simulator recovery failed. Aborting operation.');
         }
 

--- a/src/index.js
+++ b/src/index.js
@@ -1,9 +1,15 @@
-const util = require("util");
-const exec = util.promisify(require("child_process").exec);
-const debug = require("debug")("testcafe:browser-provider-ios");
-const deviceList = require("./device_list.js");
-const idbCompanion = require("./idb_companion.js");
-const process = require("process");
+const util = require('util');
+const exec = util.promisify(require('child_process').exec);
+const debug = require('debug')('testcafe:browser-provider-ios');
+const deviceList = require('./device_list.js');
+const idbCompanion = require('./idb_companion.js');
+const process = require('process');
+
+/**
+ * A utility function to introduce a delay.
+ * @param ms - The delay in milliseconds.
+ */
+const delay = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
 
 module.exports = {
   // Multiple browsers support
@@ -14,7 +20,7 @@ module.exports = {
   availableDevices: [],
 
   _browserNameToDevice(browserName) {
-    const [device, version = "any"] = browserName.split(":");
+    const [device, version = 'any'] = browserName.split(':');
 
     return deviceList.find(this.availableDevices, {
       name: device,
@@ -24,42 +30,68 @@ module.exports = {
 
   async openBrowser(id, pageUrl, browserName) {
     debug(`Opening ${browserName}`);
-    var device = this._browserNameToDevice(browserName);
+    const device = this._browserNameToDevice(browserName);
 
     if (device === null)
-      throw new Error("Could not find a valid iOS device to test on");
+      throw new Error('Could not find a valid iOS device to test on');
 
     this.currentBrowsers[id] = device;
 
     // If the device is not Shutdown we don't know what state it's in - shut it down and reboot it
-    if (device.state !== "Shutdown") {
-      debug("Forcing shutdown of device before test");
+    if (device.state !== 'Shutdown') {
+      debug('Forcing shutdown of device before test');
       await idbCompanion.shutdown(device.udid);
     }
 
     debug(`Booting device (${device.name} ${device.os} ${device.version})`);
     // Timeout in seconds
     const timeout = process.env.IOS_BOOT_TIMEOUT || 60;
-
     await idbCompanion.boot(device.udid, timeout * 1000);
 
-    debug(`Opening url: ${pageUrl}`);
-    await exec(`xcrun simctl openurl ${device.udid} ${pageUrl}`, {
-      stdio: "ignore",
-    });
+    const maxRetries = 5;
+    const retryDelay = 2000;
+    let attempt = 0;
+
+    while (attempt < maxRetries) {
+      attempt++;
+
+      try {
+        // Try opening the URL on the device by udid
+        await exec(`xcrun simctl openurl ${device.udid} ${pageUrl}`);
+        return; // Success, exit function.
+      } catch (error) {
+
+        if (attempt >= maxRetries) {
+          throw new Error(
+            `Failed to open URL on simulator after ${maxRetries} attempts.`,
+          );
+        }
+
+        // Start recovery process
+        try {
+          // Use idbCompanion for consistency with the rest of the file
+          await idbCompanion.shutdown(device.udid);
+          await idbCompanion.boot(device.udid, timeout * 1000);
+        } catch (recoveryError) {
+          throw new Error('Simulator recovery failed. Aborting operation.');
+        }
+
+        await delay(retryDelay);
+      }
+    }
   },
 
   async closeBrowser(id) {
-    const skipShutdown = process.env.IOS_SKIP_SHUTDOWN || "";
+    const skipShutdown = process.env.IOS_SKIP_SHUTDOWN || '';
 
-    if (skipShutdown !== "") return;
+    if (skipShutdown !== '') return;
 
     await idbCompanion.shutdown(this.currentBrowsers[id].udid);
   },
 
   // Optional - implement methods you need, remove other methods
   async init() {
-    debug("Initializing plugin");
+    debug('Initializing plugin');
     var rawDevices = await idbCompanion.list();
 
     this.availableDevices = deviceList.parse(rawDevices);
@@ -85,6 +117,6 @@ module.exports = {
   async takeScreenshot(id, screenshotPath) {
     var command = `xcrun simctl io ${this.currentBrowsers[id].udid} screenshot '${screenshotPath}'`;
 
-    await exec(command, { stdio: "ignore" });
+    await exec(command, { stdio: 'ignore' });
   },
 };

--- a/src/index.js
+++ b/src/index.js
@@ -1,9 +1,9 @@
-const util = require('util');
-const exec = util.promisify(require('child_process').exec);
-const debug = require('debug')('testcafe:browser-provider-ios');
-const deviceList = require('./device_list.js');
-const idbCompanion = require('./idb_companion.js');
-const process = require('process');
+const util = require("util");
+const exec = util.promisify(require("child_process").exec);
+const debug = require("debug")("testcafe:browser-provider-ios");
+const deviceList = require("./device_list.js");
+const idbCompanion = require("./idb_companion.js");
+const process = require("process");
 
 /**
  * A utility function to introduce a delay.
@@ -20,7 +20,7 @@ module.exports = {
   availableDevices: [],
 
   _browserNameToDevice(browserName) {
-    const [device, version = 'any'] = browserName.split(':');
+    const [device, version = "any"] = browserName.split(":");
 
     return deviceList.find(this.availableDevices, {
       name: device,
@@ -33,13 +33,13 @@ module.exports = {
     const device = this._browserNameToDevice(browserName);
 
     if (device === null)
-      throw new Error('Could not find a valid iOS device to test on');
+      throw new Error("Could not find a valid iOS device to test on");
 
     this.currentBrowsers[id] = device;
 
     // If the device is not Shutdown we don't know what state it's in - shut it down and reboot it
-    if (device.state !== 'Shutdown') {
-      debug('Forcing shutdown of device before test');
+    if (device.state !== "Shutdown") {
+      debug("Forcing shutdown of device before test");
       await idbCompanion.shutdown(device.udid);
     }
 
@@ -74,7 +74,7 @@ module.exports = {
           await idbCompanion.boot(device.udid, timeout * 1000);
         } catch (recoveryError) {
           debug(`Recovery error: ${recoveryError}`);
-          throw new Error('Simulator recovery failed. Aborting operation.');
+          throw new Error("Simulator recovery failed. Aborting operation.");
         }
 
         await delay(retryDelay);
@@ -83,16 +83,16 @@ module.exports = {
   },
 
   async closeBrowser(id) {
-    const skipShutdown = process.env.IOS_SKIP_SHUTDOWN || '';
+    const skipShutdown = process.env.IOS_SKIP_SHUTDOWN || "";
 
-    if (skipShutdown !== '') return;
+    if (skipShutdown !== "") return;
 
     await idbCompanion.shutdown(this.currentBrowsers[id].udid);
   },
 
   // Optional - implement methods you need, remove other methods
   async init() {
-    debug('Initializing plugin');
+    debug("Initializing plugin");
     var rawDevices = await idbCompanion.list();
 
     this.availableDevices = deviceList.parse(rawDevices);
@@ -118,6 +118,6 @@ module.exports = {
   async takeScreenshot(id, screenshotPath) {
     var command = `xcrun simctl io ${this.currentBrowsers[id].udid} screenshot '${screenshotPath}'`;
 
-    await exec(command, { stdio: 'ignore' });
+    await exec(command, { stdio: "ignore" });
   },
 };

--- a/src/index.js
+++ b/src/index.js
@@ -64,8 +64,12 @@ module.exports = {
       } catch (error) {
         debug(`Error opening URL: ${error}`);
         if (attempt >= maxRetries) {
+          if (error instanceof Error) {
+            error.message = `Failed to open URL on simulator after ${maxRetries} attempts. Last error: ${error.message}`;
+            throw error;
+          }
           throw new Error(
-            `Failed to open URL on simulator after ${maxRetries} attempts. Last error: ${error instanceof Error ? error.message : String(error)}`,
+            `Failed to open URL on simulator after ${maxRetries} attempts. Last error: ${String(error)}`,
           );
         }
 

--- a/src/index.js
+++ b/src/index.js
@@ -9,7 +9,9 @@ const process = require("process");
  * A utility function to introduce a delay.
  * @param ms - The delay in milliseconds.
  */
-const delay = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
+const util = require("util");
+
+const delay = util.promisify(setTimeout);
 
 module.exports = {
   // Multiple browsers support

--- a/src/index.js
+++ b/src/index.js
@@ -63,7 +63,7 @@ module.exports = {
         debug(`Error opening URL: ${error}`);
         if (attempt >= maxRetries) {
           throw new Error(
-            `Failed to open URL on simulator after ${maxRetries} attempts.`,
+            `Failed to open URL on simulator after ${maxRetries} attempts. Last error: ${error instanceof Error ? error.message : String(error)}`,
           );
         }
 
@@ -74,7 +74,9 @@ module.exports = {
           await idbCompanion.boot(device.udid, timeout * 1000);
         } catch (recoveryError) {
           debug(`Recovery error: ${recoveryError}`);
-          throw new Error("Simulator recovery failed. Aborting operation.");
+          throw new Error(
+            `Simulator recovery failed. Aborting operation. Error: ${recoveryError instanceof Error ? recoveryError.message : String(recoveryError)}`,
+          );
         }
 
         await delay(retryDelay);


### PR DESCRIPTION
## Description
Adding retry logic to openurl command that will shutdown the simulator, re-launch the device, and attempt the openurl command again.